### PR TITLE
refactor: simplified character stream

### DIFF
--- a/src/character-stream.ts
+++ b/src/character-stream.ts
@@ -1,3 +1,5 @@
+import * as Types from './types';
+
 export class CharacterStream {
 
   private _offset: number = 0;
@@ -28,7 +30,7 @@ export class CharacterStream {
     return this._offset;
   }
 
-  get pos(): {line: number; column: number; char: number} {
+  get pos(): Types.PositionPart {
     return {
       line: this.line,
       column: this.column,
@@ -57,16 +59,8 @@ export class CharacterStream {
   }
 
   public accept(text: string): void {
-    const remember = this._offset;
-    try {
-      for (let i = 0, n = text.length; i < n; i++) {
-        this.expect(text.charAt(i));
-        this.next();
-      }
-    } catch (e) {
-      this._offset = remember;
-      throw new Error(`Unexpected character '${this.ch}' at ${this.line}:${this.column}. Expected '${text}'`);
-    }
+      this.expect(text);
+      this.next();
   }
 
   public skip(text: string): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,15 @@ import { CharacterStream } from './character-stream';
 import * as Types from './types';
 export * from './types';
 
+/**
+ * Parses a given string into a Json AST.
+ * This parser does some error correction (notably missing comma in objects and arrays).
+ * The template parameter could be used to qualify the result AST.
+ * 
+ * @export
+ * @param {string} text The Json text to parse
+ * @returns {JsonObject|JsonArray} Either a Json Object or Json Array AST node
+ */
 export default function parse<T extends Types.JsonObject|Types.JsonArray>(text: string): T {
   let result: Types.JsonNode | undefined = undefined;
   const cs = new CharacterStream(text);
@@ -101,20 +110,22 @@ function array(cs: CharacterStream): Types.JsonArray {
 
 function value(cs: CharacterStream): Types.JsonValue {
   ws(cs);
-  if (cs.ch === '"') {
-    return string(cs);
-  } else if (cs.ch === '{') {
-    return object(cs);
-  } else if (cs.ch === '[') {
-    return array(cs);
-  } else if (cs.ch === 't') {
-    return trueLiteral(cs);
-  } else if (cs.ch === 'f') {
-    return falseLiteral(cs);
-  } else if (cs.ch === 'n') {
-    return nullLiteral(cs);
+  switch (cs.ch) {
+    case '"':
+      return string(cs);
+    case '{':
+      return object(cs);
+    case '[':
+      return array(cs);
+    case 't':
+      return trueLiteral(cs);
+    case 'f':
+      return falseLiteral(cs);
+    case 'n':
+      return nullLiteral(cs);
+    default:
+      return number(cs);
   }
-  return number(cs);
 }
 
 function string(cs: CharacterStream): Types.JsonString {
@@ -139,7 +150,10 @@ function string(cs: CharacterStream): Types.JsonString {
 function trueLiteral(cs: CharacterStream): Types.JsonLiteral {
   ws(cs);
   const start = cs.pos;
-  cs.accept('true');
+  cs.accept('t');
+  cs.accept('r');
+  cs.accept('u');
+  cs.accept('e');
   return {
     type: 'true',
     pos: {
@@ -152,7 +166,11 @@ function trueLiteral(cs: CharacterStream): Types.JsonLiteral {
 function falseLiteral(cs: CharacterStream): Types.JsonLiteral {
   ws(cs);
   const start = cs.pos;
-  cs.accept('false');
+  cs.accept('f');
+  cs.accept('a');
+  cs.accept('l');
+  cs.accept('s');
+  cs.accept('e');
   return {
     type: 'false',
     pos: {
@@ -165,7 +183,10 @@ function falseLiteral(cs: CharacterStream): Types.JsonLiteral {
 function nullLiteral(cs: CharacterStream): Types.JsonLiteral {
   ws(cs);
   const start = cs.pos;
-  cs.accept('null');
+  cs.accept('n');
+  cs.accept('u');
+  cs.accept('l');
+  cs.accept('l');
   return {
     type: 'null',
     pos: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,14 +1,12 @@
 export interface Position {
-  start: {
-    line: number;
-    column: number;
-    char: number;
-  };
-  end: {
-    line: number;
-    column: number;
-    char: number;
-  };
+  start: PositionPart;
+  end: PositionPart;
+}
+
+export interface PositionPart {
+  line: number;
+  column: number;
+  char: number;
 }
 
 export interface JsonNode {

--- a/test/character-stream.test.ts
+++ b/test/character-stream.test.ts
@@ -61,15 +61,6 @@ test('CharacterStream should increment line and offset on read newline', t => {
   t.is(cs.offset, 1);
 });
 
-test('CharacterStream should accept multiple characters at once', t => {
-  const cs = new CharacterStream('abc');
-  cs.accept('ab');
-  t.is(cs.ch, 'c');
-  t.is(cs.line, 1);
-  t.is(cs.column, 3);
-  t.is(cs.offset, 2);
-});
-
 test('CharacterStream should throw if multiple characters could not be accepted', t => {
   const cs = new CharacterStream('abc');
   t.throws(() => cs.accept('abd'), /Unexpected character/);


### PR DESCRIPTION
remove accepting strings in favor of more simple characters only. This reduces character stream
complexity by strictly be LA(1).